### PR TITLE
Fix & Cleanup

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,17 +31,18 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".UmatRootActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Umat.NoActionBar" >
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <data android:mimeType="text/plain" />
             </intent-filter>
         </activity>
-
-        <activity
-            android:name=".UmatRootActivity"
-            android:exported="true"
-            android:theme="@style/Theme.Umat.NoActionBar" />
 
     </application>
 

--- a/app/src/main/java/com/teople/umat/UmatSplashActivity.kt
+++ b/app/src/main/java/com/teople/umat/UmatSplashActivity.kt
@@ -38,13 +38,13 @@ class UmatSplashActivity : ComponentActivity() {
     @SuppressLint("UseCompatLoadingForDrawables")
     override fun onCreate(savedInstanceState: Bundle?) {
 
+        actionBar?.hide()
+
         enableEdgeToEdge()
 
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.S) {
 
             splashScreen.setOnExitAnimationListener { splashScreenView ->
-
-                actionBar?.hide()
 
                 splashScreenView.background = getDrawable(R.drawable.img_splash_background)
 
@@ -56,6 +56,7 @@ class UmatSplashActivity : ComponentActivity() {
 
                     doOnEnd {
                         startActivity(Intent(this@UmatSplashActivity, UmatRootActivity::class.java))
+                        finish()
                     }
                 }.start()
             }
@@ -67,10 +68,7 @@ class UmatSplashActivity : ComponentActivity() {
             lifecycleScope.launch {
                 lifecycle.repeatOnLifecycle(Lifecycle.State.CREATED) {
                     delay(SPLASH_DELAY)
-                    Intent(
-                        this@UmatSplashActivity,
-                        UmatRootActivity::class.java
-                    ).let(::startActivity)
+                    startActivity(Intent(this@UmatSplashActivity, UmatRootActivity::class.java))
                     finish()
                 }
             }

--- a/app/src/main/java/com/teople/umat/route/UmatRootRoute.kt
+++ b/app/src/main/java/com/teople/umat/route/UmatRootRoute.kt
@@ -1,5 +1,6 @@
 package com.teople.umat.route
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -24,6 +25,10 @@ fun UmatRootRoute(
 ) {
     var sharedQuery by rememberSaveable {
         mutableStateOf(sharedTitle)
+    }
+
+    BackHandler {
+        // TODO("Activity Finish & SplashActivity Issue")
     }
 
     NavHost(

--- a/app/src/main/java/com/teople/umat/screen/MainScreen.kt
+++ b/app/src/main/java/com/teople/umat/screen/MainScreen.kt
@@ -1,7 +1,6 @@
 package com.teople.umat.screen
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -42,7 +41,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hierarchy
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -63,6 +61,7 @@ import com.teople.umat.component.ui.theme.Gray700
 import com.teople.umat.component.ui.theme.Gray900
 import com.teople.umat.component.ui.theme.UmatTheme
 import com.teople.umat.component.ui.theme.UmatTypography
+import com.teople.umat.component.ui.theme.noRippleClickable
 import com.teople.umat.component.widget.component.UmatSelectBottomSheet
 import com.teople.umat.feature.home.HomeScreen
 import com.teople.umat.feature.mypage.MypageScreen
@@ -168,6 +167,7 @@ fun MainScreen(
                         navController.navigate(
                             route = "${BottomNavItem.Home.screenRoute}?selectedPlace=${Gson().toJson(viewState.selectedPlace)}"
                         )
+                        viewModel.removeSelectedPlace()
                     },
                     actionNegative = {
                         // 뒤로가기, 바텀시트 종료
@@ -246,16 +246,16 @@ fun RowScope.BottomNavButton(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .clickable(
-                onClick = {
-                    if (!selected) {
-                        navController.navigate(screen.screenRoute) {
-                            popUpTo(navController.graph.findStartDestination().id)
-                            launchSingleTop = true
-                        }
-                    }
-                })
             .padding(bottom = 14.dp)
+            .noRippleClickable {
+                navController.navigate(screen.screenRoute) {
+                    popUpTo(navController.graph.id) {
+                        saveState = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }
             .weight(1f)
     ) {
         Column(

--- a/component/src/main/java/com/teople/umat/component/ui/theme/Modifier.kt
+++ b/component/src/main/java/com/teople/umat/component/ui/theme/Modifier.kt
@@ -1,0 +1,39 @@
+package com.teople.umat.component.ui.theme
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+
+fun Modifier.rippleClickable(
+    onClick: () -> Unit
+) = composed(
+    factory = {
+        this.then(
+            Modifier.clickable(
+                interactionSource = remember {
+                    MutableInteractionSource()
+                },
+                indication = CustomIndication,
+                onClick = { onClick() }
+            )
+        )
+    }
+)
+
+fun Modifier.noRippleClickable(
+    onClick: () -> Unit
+) = composed(
+    factory = {
+        this.then(
+            Modifier.clickable(
+                interactionSource = remember {
+                    MutableInteractionSource()
+                },
+                indication = null,
+                onClick = { onClick() }
+            )
+        )
+    }
+)

--- a/component/src/main/java/com/teople/umat/component/ui/theme/Theme.kt
+++ b/component/src/main/java/com/teople/umat/component/ui/theme/Theme.kt
@@ -1,12 +1,23 @@
 package com.teople.umat.component.ui.theme
 
+import androidx.compose.foundation.Indication
+import androidx.compose.foundation.IndicationInstance
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.ProvideTextStyle
+import androidx.compose.material.ripple.LocalRippleTheme
+import androidx.compose.material.ripple.RippleAlpha
+import androidx.compose.material.ripple.RippleTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.ContentDrawScope
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 
 /**
@@ -62,7 +73,8 @@ fun UmatTheme(
 
     CompositionLocalProvider(
         LocalColors provides rememberedColors,
-        LocalTypography provides typography
+        LocalTypography provides typography,
+        LocalRippleTheme provides CustomRippleTheme
     ) {
         ProvideTextStyle(value = typography.lineSeedBold20, content = content)
     }
@@ -80,6 +92,50 @@ fun UmatTheme(
                 color = rememberedColors.background,
                 darkIcons = useDarkIcons
             )
+        }
+    }
+}
+
+@Immutable
+private object CustomRippleTheme : RippleTheme {
+
+    @Composable
+    override fun defaultColor() = Color.Unspecified
+
+    @Composable
+    override fun rippleAlpha() = RippleAlpha(
+        draggedAlpha = 0.0f,
+        focusedAlpha = 0.0f,
+        hoveredAlpha = 0.0f,
+        pressedAlpha = 0.0f,
+    )
+}
+
+@Immutable
+object CustomIndication: Indication {
+
+    @Immutable
+    private class DefaultIndicationInstance(
+        private val isPressed: State<Boolean>
+    ) : IndicationInstance {
+        override fun ContentDrawScope.drawIndication() {
+            drawContent()
+            if (isPressed.value) {
+                drawRect(
+                    color = Gray500.copy(
+                        alpha = 0.1f
+                    ),
+                    size = size
+                )
+            }
+        }
+    }
+
+    @Composable
+    override fun rememberUpdatedInstance(interactionSource: InteractionSource): IndicationInstance {
+        val isPressed = interactionSource.collectIsPressedAsState()
+        return remember(interactionSource) {
+            DefaultIndicationInstance(isPressed)
         }
     }
 }

--- a/component/src/main/java/com/teople/umat/component/widget/component/UmatButton.kt
+++ b/component/src/main/java/com/teople/umat/component/widget/component/UmatButton.kt
@@ -1,4 +1,4 @@
-package com.teople.umat.component.widget
+package com.teople.umat.component.widget.component
 
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import com.teople.umat.component.R
 
 @Composable
-fun ComponentButton(
+fun UmatButton(
     modifier: Modifier = Modifier,
     backgroundColor: Color,
     text: String,
@@ -51,9 +51,9 @@ fun ComponentButton(
 
 @Preview
 @Composable
-fun ComponentButtonPreview() {
+fun UmatButtonPreview() {
     val painter = painterResource(id = R.drawable.ic_apple)
-    ComponentButton(
+    UmatButton(
         modifier = Modifier
             .fillMaxWidth()
             .padding(16.dp),

--- a/feature/home/src/main/java/com/teople/umat/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/teople/umat/feature/home/HomeScreen.kt
@@ -81,6 +81,7 @@ import com.teople.umat.component.ui.theme.Gray400
 import com.teople.umat.component.ui.theme.Gray600
 import com.teople.umat.component.ui.theme.Gray800
 import com.teople.umat.component.ui.theme.UmatTypography
+import com.teople.umat.component.ui.theme.noRippleClickable
 import com.teople.umat.component.widget.component.UmatItemCard
 import com.teople.umat.feature.home.HomeViewModel.Companion.SEOUL_LAT
 import com.teople.umat.feature.home.HomeViewModel.Companion.SEOUL_LNG
@@ -237,10 +238,11 @@ fun HomeScreen(
                 CurrentPositionButton(
                     modifier = Modifier
                         .align(Alignment.CenterHorizontally)
-                        .clickable {
+                        .noRippleClickable {
                             drawCurrentPositionCircle()
                             currentPositionBoundRequested = true
-                        })
+                        }
+                )
             }
         }
     }

--- a/feature/home/src/main/java/com/teople/umat/feature/home/component/HomeSearchBar.kt
+++ b/feature/home/src/main/java/com/teople/umat/feature/home/component/HomeSearchBar.kt
@@ -2,7 +2,6 @@ package com.teople.umat.feature.home.component
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -17,7 +16,6 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -30,6 +28,7 @@ import com.teople.umat.component.ui.theme.Gray400
 import com.teople.umat.component.ui.theme.UmatTheme
 import com.teople.umat.component.ui.theme.UmatTypography
 import com.teople.umat.component.ui.theme.White
+import com.teople.umat.component.ui.theme.noRippleClickable
 import com.teople.umat.component.widget.preview.UmatPreview
 import com.teople.umat.feature.home.R
 
@@ -64,10 +63,7 @@ fun HomeSearchBar(
                     color = White,
                     shape = RoundedCornerShape(6.dp)
                 )
-                .clip(
-                    shape = RoundedCornerShape(6.dp)
-                )
-                .clickable {
+                .noRippleClickable {
                     actionSearchClick()
                 }
                 .padding(

--- a/feature/mypage/src/main/java/com/teople/umat/feature/mypage/MypageScreen.kt
+++ b/feature/mypage/src/main/java/com/teople/umat/feature/mypage/MypageScreen.kt
@@ -54,7 +54,7 @@ import com.teople.umat.component.ui.theme.Gray800
 import com.teople.umat.component.ui.theme.Gray900
 import com.teople.umat.component.ui.theme.Orange500
 import com.teople.umat.component.ui.theme.UmatTheme
-import com.teople.umat.component.widget.ComponentButton
+import com.teople.umat.component.widget.component.UmatButton
 import com.teople.umat.component.widget.component.UmatAppBar
 import com.teople.umat.component.widget.component.UmatBadge
 import com.teople.umat.component.widget.component.UmatBadgeDefaults
@@ -360,7 +360,7 @@ private fun MypageAllergySection(
                 )
 
                 // TODO("Component : Outlined Button 작업")
-                ComponentButton(
+                UmatButton(
                     backgroundColor = Gray300,
                     text = stringResource(id = R.string.mypage_allergy_default_register),
                     textColor = Gray800,

--- a/feature/mypage/src/main/java/com/teople/umat/feature/mypage/setting/MypageSettingAllergyScreen.kt
+++ b/feature/mypage/src/main/java/com/teople/umat/feature/mypage/setting/MypageSettingAllergyScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -29,7 +28,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -39,7 +37,7 @@ import com.teople.umat.component.ui.theme.Gray500
 import com.teople.umat.component.ui.theme.Gray800
 import com.teople.umat.component.ui.theme.Gray900
 import com.teople.umat.component.ui.theme.UmatTheme
-import com.teople.umat.component.widget.ComponentButton
+import com.teople.umat.component.widget.component.UmatButton
 import com.teople.umat.component.widget.component.UmatAppBar
 import com.teople.umat.component.widget.component.UmatLabel
 import com.teople.umat.component.widget.preview.UmatPreview
@@ -86,7 +84,7 @@ fun MypageSettingAllergyScreen() {
             )
         },
         bottomBar = {
-            ComponentButton(
+            UmatButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(

--- a/feature/onboarding/src/main/java/com/teople/onboarding/ui/OnBoardingScreen.kt
+++ b/feature/onboarding/src/main/java/com/teople/onboarding/ui/OnBoardingScreen.kt
@@ -47,7 +47,7 @@ import com.teople.umat.component.ui.theme.Gray500
 import com.teople.umat.component.ui.theme.Gray800
 import com.teople.umat.component.ui.theme.Gray900
 import com.teople.umat.component.ui.theme.Gray950
-import com.teople.umat.component.widget.ComponentButton
+import com.teople.umat.component.widget.component.UmatButton
 import com.teople.umat.component.widget.component.UmatTextField
 import com.teople.umat.component.widget.component.UmatTextFieldDefaults
 import com.teople.umat.component.widget.component.UmatTransition
@@ -120,7 +120,7 @@ fun GuideScreen(
                     contentScale = ContentScale.Crop
                 )
             }
-            ComponentButton(
+            UmatButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(horizontal = 24.dp)
@@ -155,7 +155,7 @@ fun SocialLoginScreen(
                     .fillMaxWidth()
                     .padding(top = 61.dp)
             ) {
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 24.dp)
@@ -174,7 +174,7 @@ fun SocialLoginScreen(
                         )
                     }
                 )
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(horizontal = 24.dp)
@@ -285,7 +285,7 @@ fun NicknameScreen(
                     }
                 )
 
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 114.dp)
@@ -378,7 +378,7 @@ fun ConnectScreen(
                         modifier = Modifier.align(alignment = Alignment.Center)
                     )
                 }
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 80.dp)
@@ -388,7 +388,7 @@ fun ConnectScreen(
                     textColor = Color.White,
                     onClick = { viewModel.onClickConnect() }
                 )
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 16.dp)
@@ -463,7 +463,7 @@ fun CodeInputScreen(
                         viewModel.onInviteCodeTextFieldValueChange(newValue)
                     }
                 )
-                ComponentButton(
+                UmatButton(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(top = 114.dp)

--- a/feature/search/src/main/java/com/teople/umat/feature/search/component/SearchResultRow.kt
+++ b/feature/search/src/main/java/com/teople/umat/feature/search/component/SearchResultRow.kt
@@ -2,7 +2,6 @@ package com.teople.umat.feature.search.component
 
 import android.content.res.Configuration
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,6 +22,7 @@ import com.teople.umat.component.ui.theme.Gray200
 import com.teople.umat.component.ui.theme.Gray400
 import com.teople.umat.component.ui.theme.Gray950
 import com.teople.umat.component.ui.theme.UmatTypography
+import com.teople.umat.component.ui.theme.noRippleClickable
 import com.teople.umat.component.widget.preview.UmatPreview
 import com.teople.umat.core.data.entity.CoreGooglePlacesSearchEntity
 
@@ -34,10 +34,10 @@ fun SearchResultRow(
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(18.dp)
-            .clickable {
+            .noRippleClickable {
                 actionItemClick(item)
-            },
+            }
+            .padding(18.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(12.dp)
     ) {


### PR DESCRIPTION
## Overview (Required)
- SplashActivity 가 RouteActivity 이동 후에도 남아있는 현상 수정
- 하단 바텀 네비게이션 클릭 시 크래시 현상 수정
- 홈 검색바, 저장장소 등 noRippleClickable 커스텀 & 적용
- 앱 테마 전체 RippleTheme 이 동작하지 않도록 CustomRippleTheme 추가
- 검색 아이템 추가하기 시 캐싱하고 있는 장소 상세 데이터(ViewState) 를 비워주도록 추가
